### PR TITLE
LogRocket no longer accept new Guest Author

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ A list of companies that have paid Developer Community Writer Programs.
   > Technical tutorials with code. Pick from a list of possible articles.
 
 - [StackOverflow](https://stackoverflow.blog/2020/01/27/blog-contributor-guidelines/?cb=1) - $500 per piece
-  > Technical focused articles. No limitation on topics.
+  > Software engineering focused articles. No tutorials and should be of interest to a wide range of developers.
 
 - [Strapi](https://strapi.io/write-for-the-community) - Up to $200 per piece
   > Articles or tutorials with code covering use-cases, solutions and projects built with Strapi that include Vue, Open Source, JavaScript, GraphQL, Jamstack, React. Pick from a list of possible articles or pitch your own.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Arctype](https://arctype.com/blog/contribute/) - $100+ per article
   > Technical guides, case studies, and thought leadership on SQL and Databases.
 
-- [Auth0](https://auth0.com/guest-authors) - Up to $450 per piece
-  > Technical tutorials with code. Pick from a list of possible articles.
-  **Applications are closed at the moment.**
 - [Baeldung](https://www.baeldung.com/contribution-guidelines) - $40 - $150 (for articles; they accept also mini-articles and improvments (Java))
   > Baeldung is a technical site focused mainly on the Java ecosystem, but also Kotlin, Scala, Linux, and general Computer Science – with a reach of about 10M page views per month. We publish tutorials and how-to articles – with a very practical, code-focused, and to-the-point style.
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [GraphCMS](https://graphcms.com/write-for-graphcms) - Up to $300 per piece
   > Technical tutorials or blogs with code about GraphCMS or GraphQL with Jamstack or tooling of your choice.
 
-- [Hashnode](https://web3.hashnode.com/contribute) - $300 per article
+- [Hashnode Web3 Blog](https://web3.hashnode.com/contribute) - $300 per article
   > Technical content and tutorials related to Web3.
 
 - [Hasura](https://blog.hasura.io/the-hasura-technical-writer-program/) - Up to $300 per piece

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Agora](https://www.agora.io/en/agora-content-contributor-program/) - $250 per article
   > Technical content and tutorials for the Agora community.
 
-- [Airbyte](https://airbyte.com/write-for-the-community) - $600 per article, you also get paid $300 when your article reaches 1000 views in the first month.
+- [Airbyte](https://airbyte.com/write-for-the-community) - $900 per article of about 1500 words.
   > Data engineering tutorials, tutorials that cover Airbyte use cases and features.
 
 - [Ambassador Labs](https://www.getambassador.io/write-for-us/) - $300 per article

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Neptune](https://neptune.ai/write-for-us) - $300-$600 per article.
   > Technical articles, how-to guides and tutorials on machine learning and data science.
 
+- [Okta](https://developer.okta.com/blog) - Paid through Toptal based on your hourly rate
+  > Technical tutorials and demos using Okta's products.
+
 - [Okteto](https://okteto.com/tech-writer/) - $200 per article
   > Technical content and tutorials about Okteto, Kubernetes, and Cloud-Native Applications.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Auth0](https://auth0.com/guest-authors) - Up to $450 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
-  ** Applications are closed at the moment.**
+  **Applications are closed at the moment.**
 - [Baeldung](https://www.baeldung.com/contribution-guidelines) - $40 - $150 (for articles; they accept also mini-articles and improvments (Java))
   > Baeldung is a technical site focused mainly on the Java ecosystem, but also Kotlin, Scala, Linux, and general Computer Science – with a reach of about 10M page views per month. We publish tutorials and how-to articles – with a very practical, code-focused, and to-the-point style.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Code Magic](https://blog.codemagic.io/write-for-codemagic-ci-cd/) - Applications are currently closed.
   > Technical focused articles. Specific on Flutter.
 
-- [CodingSight](https://codingsight.com) - Proposed article should be sent to [marketing@devart.com](mailto:marketing@devart.com) (payment depends on the length, research and audience) - From 100$ to 250$ based on the article technical level
+- [CodingSight](https://codingsight.com) (Email [marketing@devart.com](mailto:marketing@devart.com)) - $100-$250 per piece
   > Technical articles on SQL Server, PostgreSQL, .NET, Oracle, and Azure.
   
 - [ContentLab.io](https://contentlab.io/write-for-contentlab/) - Up to $500 per piece
@@ -137,7 +137,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Nanonet](https://nanonets.com/blog/write-for-us/)
   > Get paid to write about your favourite machine learning topics!
 
-- [MSSQLTips](https://www.mssqltips.com/contribute/) - 160$ per tip
+- [MSSQLTips](https://www.mssqltips.com/contribute/) - $160 per tip
   > Get paid to write about SQL Server and related technologies.
  
 - [Neptune](https://neptune.ai/write-for-us) - Up to $500 per article.
@@ -176,7 +176,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Section.io](https://github.com/section-io/engineering-education) - $50 to $150 per article
   > Engineering education blog where Computer Science university students may contribute content for pay.
 
-- [Simple Talk](https://www.red-gate.com/simple-talk/write-for-us/) - 350$ per article
+- [Simple Talk](https://www.red-gate.com/simple-talk/write-for-us/) - $350 per article
   > Technical articles focused on SQL Server, MySQL, and Postgres.
 
 - [SitePoint](https://sitepoint.typeform.com/to/DMmYfn) - $250 per article
@@ -190,7 +190,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Soshace](https://docs.google.com/document/d/1DZ9Hj8AcNfHI6bC4bfTDIFRNIIFnda6Mkj_n_4x3hWw/edit) - $100 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
-- [SQLShack](https://www.sqlshack.com/about-us/) - 200$ per piece
+- [SQLShack](https://www.sqlshack.com/about-us/) - $200 per piece
   > Technical focused articles. Specific on SQL Server and related technologies.
   
 - [StackOverflow](https://stackoverflow.blog/2020/01/27/blog-contributor-guidelines/?cb=1)

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ Paid writer programs usually have just enough of an incentive for people to get 
 
 A list of companies that have paid Developer Community Writer Programs.
 
-- [Alan AI](https://forms.gle/VJ3gQ2tNWqd3pLq97) - $50-$250 per article.
-  > Technical content, tutorials, building demo projects, and how-to guides that includes Alan AI platform.
-
 - [100ms](https://www.100ms.live/technical-writer-program) - $200-$500 per article.
   > Technical content and tutorials related to the 100ms SDKs.
 
@@ -24,6 +21,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Airbyte](https://airbyte.com/write-for-the-community) - $900 per article of about 1500 words.
   > Data engineering tutorials, tutorials that cover Airbyte use cases and features.
+
+- [Alan AI](https://forms.gle/VJ3gQ2tNWqd3pLq97) - $50-$250 per article.
+  > Technical content, tutorials, building demo projects, and how-to guides that includes Alan AI platform.
 
 - [Ambassador Labs](https://www.getambassador.io/write-for-us/) - $300 per article
   > Technical tutorials, guides, opinions and case studies on Kubernetes and open source cloud native technologies.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Bejamas](https://bejamas.io/paid-writing-program/) - Pay unknown
   > Jamstack, serverless and modern web development. Pitch a topic or pick from a list of possible articles.
 
-- [Bird Eats Bug](https://birdeatsbug.com/jobs/technical-content-writer) - $100 - $300 (Tutorial)
+- [Bird Eats Bug](https://jobs.birdeatsbug.com/o/freelance-technical-content-writer-fmx/c/new) - $100 - $300 (Tutorial)
   > Write technical content related to Bird Eats Bug or software development and we will compensate you between $100-$300 for each article of yours that gets publish, depending on the quality and scope of the article.
 
 - [CircleCI](https://circleci.com/blog/guest-writer-program/) - Up to $300 per piece

--- a/README.md
+++ b/README.md
@@ -41,11 +41,9 @@ A list of companies that have paid Developer Community Writer Programs.
   > Jamstack, serverless and modern web development. Pitch a topic or pick from a list of possible articles
 - [Bird Eats Bug](https://birdeatsbug.com/jobs/technical-content-writer) - $100 - $300 (Tutorial)
   > Write technical content related to Bird Eats Bug or software development and we will compensate you between $100-$300 for each article of yours that gets publish, depending on the quality and scope of the article.
+
 - [CircleCI](https://circleci.com/blog/guest-writer-program/)  - Up to $300 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
-
-- [Clubhouse.io](https://clubhouse.io/clubhouse-write-earn-give-program/) - Up to $600 per piece
-  > Technical tutorials and how-to guides. Pick from a list of possible articles.
 
 - [Code Tuts+](https://code.tutsplus.com/articles/call-for-authors-write-for-tuts--cms-22034) - $100 (Quick tip) $250 (Tutorial)
   > Technical focused articles. Pick from a list of possible articles.
@@ -153,7 +151,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Rancher](https://rancher.com/writing-program/roles/writer/) - $300 per piece
   > Writing about devops, Kubernetes, and Rancher.
 
-- [Real Python](https://realpython.com/write-for-us/) - Applications are currently (as of Aug/21) closed. 
+- [Real Python](https://realpython.com/write-for-us/) - **Applications currently on hold** 
   > Technical tutorials with code. Pick from a list of possible articles.
 
 - [Sanity.io](https://www.sanity.io/guest-authorship) - Up to $250 per piece

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [GraphCMS](https://graphcms.com/write-for-graphcms) - Up to $300 per piece
   > Technical tutorials or blogs with code about GraphCMS or GraphQL with Jamstack or tooling of your choice.
 
-- [Hashnode Web3 Blog](https://web3.hashnode.com/contribute) - $300 per article
+- [Hashnode Web3 Blog](https://web3.hashnode.com/contribute) - from 150$ - 400$ per article
   > Technical content and tutorials related to Web3.
 
 - [Hasura](https://blog.hasura.io/the-hasura-technical-writer-program/) - Up to $300 per piece

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Hasura](https://blog.hasura.io/the-hasura-technical-writer-program/) - Up to $300 per piece
   > Technical tutorials with code about Hasura or GraphQL.
 
+- [Heartbeat by Comet](https://heartbeat.comet.ml/call-for-contributors-fee7f5b80f3e) - [over $150](https://www.youtube.com/watch?v=e_B0vt-eWPw) per piece
+  > Technical content related to Trends in machine learning research, explorations of new tools and libraries and data science.
+
 - [Hedera](https://github.com/hashgraph/hedera-heroes) - $100 per piece
   > Articles must feature Hedera technologies and cryptography.
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Baeldung](https://www.baeldung.com/contribution-guidelines) - $40 - $150 (for articles; they accept also mini-articles and improvments (Java))
   > Baeldung is a technical site focused mainly on the Java ecosystem, but also Kotlin, Scala, Linux, and general Computer Science – with a reach of about 10M page views per month. We publish tutorials and how-to articles – with a very practical, code-focused, and to-the-point style.
 
-- [Bejamas](https://bejamas.io/paid-writing-program/) - Waiting for details
-  > Jamstack, serverless and modern web development. Pitch a topic or pick from a list of possible articles
+- [Bejamas](https://bejamas.io/paid-writing-program/) - Pay unknown
+  > Jamstack, serverless and modern web development. Pitch a topic or pick from a list of possible articles.
 
 - [Bird Eats Bug](https://birdeatsbug.com/jobs/technical-content-writer) - $100 - $300 (Tutorial)
   > Write technical content related to Bird Eats Bug or software development and we will compensate you between $100-$300 for each article of yours that gets publish, depending on the quality and scope of the article.
@@ -52,8 +52,8 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Code Tuts+](https://code.tutsplus.com/articles/call-for-authors-write-for-tuts--cms-22034) - $100 (Quick tip) $250 (Tutorial)
   > Technical focused articles. Pick from a list of possible articles.
 
-- [Code Magic](https://blog.codemagic.io/write-for-codemagic-ci-cd/) - Applications are currently closed.
-  > Technical focused articles. Specific on Flutter.
+- [Code Magic](https://blog.codemagic.io/write-for-codemagic-ci-cd/) - Pay unknown
+  > Technical articles about Flutter.
 
 - [ContentLab.io](https://contentlab.io/write-for-contentlab/) - Up to $500 per piece
   > Articles on the Cloud, DevOps, Containers, AI/ML, Security, Web, and Gaming spaces.
@@ -67,34 +67,31 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Cube Dev](https://www.notion.so/Cube-js-Guest-Authors-8ddd5046be9048d9869410b60d4a2b98) — Up to $300 per piece
   > Technical tutorials and blog posts with code on [Cube.js](https://cube.dev), building analytical apps, data visualization, and data engineering. Pick from a list of possible articles or suggest your own.
   
-- [Deepsource](https://deepsource.io/tech-writer/) - Around $150 per piece  
+- [Deepsource](https://deepsource.io/tech-writer/) - $150 per piece  
   > Technical Content concerning code quality, code review and static analysis
 
-- [Dev Spotlight](https://www.devspotlight.com/jobs/) - Around $300-$500 per piece depending on length and content
+- [Dev Spotlight](https://www.devspotlight.com/jobs/) - $300-$500 per piece depending on length and content
   > Technical content production agency that works with many clients.
 
-- [Digital Ocean](https://www.digitalocean.com/write-for-donations/) - Up to $400 per piece **Applications currently on hold, please check back on the first of March 2022!**
+- [Digital Ocean](https://www.digitalocean.com/community/pages/write-for-digitalocean) - Up to $400 per piece
   > Technical tutorials with code. Not limited to Digital Ocean products.
 
 - [Dockship](https://dockship.io/articles) - $20
   > Machine Learning and Data Science. You need to be signed in to be able to create content.
 
-- [Doppler](https://www.doppler.com/tech-writer-program) - $100 per article
-  > Seeking deep-dive technical tutorials focussed on application security, secrets management, and developer tools.
-
 - [Draft.dev](https://draft.dev/write) - Pays $315-$578 per piece
   > Technical content agency that works with many clients. Writers who are accepted will get an email every week and access to a writer portal with dozens of topics they can choose from.
 
-- [DZone](https://dzone.com/writers-zone) - Waiting for details
-  > Broad coverage of development topics, but with heavy Java content, working hard to push into new topics and channels.
-
-- [Egghead](https://next.egghead.io/write-for-egghead) - Waiting for details
+- [Egghead](https://next.egghead.io/write-for-egghead) - Pay unknown
   > Intermediate to advanced articles covering topics on web development.
 
-- [Fauna](https://fauna.com/blog/write-with-fauna) - Up to $350 per piece **Applications currently on hold**
+- [Enlear](https://www.enlear.com/) - $50 to $150 per article
+  > Get paid to write about broad area of technical topics. Including Vue, Angular, React, Node, JS, DynamoDB
+
+- [Fauna](https://fauna.com/blog/write-with-fauna) - Up to $350 per piece
   > Content focused on technical education around serverless development and FaunaDB.
 
-- [Figment](https://www.notion.so/Contributing-to-Figment-Learn-d8ff9cdc32ca4b58838d81d07eab49bd) - Around $100 - $1000 per piece
+- [Figment](https://www.notion.so/Contributing-to-Figment-Learn-d8ff9cdc32ca4b58838d81d07eab49bd) - $100-$1000 per piece
   > Tutorials, guides, and documentation about Blockchain and Web3.
 
 - [GraphCMS](https://graphcms.com/write-for-graphcms) - Up to $300 per piece
@@ -109,10 +106,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Honeybadger](https://www.honeybadger.io/blog/write-for-us/) - From $500 per piece
   > Ruby and Elixir tutorials with code. Pick from a list of possible articles.
 
-- [ImageKit](https://form.asana.com/?hash=4a457043221411a8d81971bc930a6a932add03c8eaeec167cf1fee81db871953&id=1166170812623393) - $300 per piece
-  >  Content focused on technical guide on ImageKit and Image Optimization.
-
-- [Linode](https://www.linode.com/docs/contribute/) - Up to $300 per piece
+- [Linode](https://www.linode.com/lp/write-for-linode/) - Up to $400 per piece
   > Technical tutorials with code on Linux or Linode.
 
 - [LoginRadius](https://www.loginradius.com/blog/async/page/guest-blog) - Up to $200 per piece
@@ -125,22 +119,16 @@ A list of companies that have paid Developer Community Writer Programs.
   > Technical content and tutorials about DevSecOps, Cloud security, Kubernetes security.
 
 - [Magic](https://magic-fortmatic.typeform.com/to/Wgzsocor) - Up to $300 per piece
-  [Link to Magic Website](https://magic.link/)
-  > Technical tutorials on how to use Magic
+  > Technical tutorials on how to use Magic.link
 
 - [Make Use Of](https://www.makeuseof.com/contributor/) - $120 per piece with performance benefits
   > Tutorials and features about consumer apps and software products.
 
-- [Mixster](https://mixstersite.wordpress.com/2019/05/24/mixster/#more-2253)
+- [Nanonet](https://nanonets.com/blog/write-for-us/) - Pay unknown
+  > Get paid to write about your favorite machine learning topics.
 
-- [Nanonet](https://nanonets.com/blog/write-for-us/)
-  > Get paid to write about your favourite machine learning topics!
-
-- [Neptune](https://neptune.ai/write-for-us) - Up to $500 per article.
+- [Neptune](https://neptune.ai/write-for-us) - $300-$600 per article.
   > Technical articles, how-to guides and tutorials on machine learning and data science.
-
-- [Okta](https://developer.okta.com/blog) - Paid through Toptal based on your hourly rate
-  > Technical tutorials and demos using Okta's products.
 
 - [Okteto](https://okteto.com/tech-writer/) - $200 per article
   > Technical content and tutorials about Okteto, Kubernetes, and Cloud-Native Applications.
@@ -154,23 +142,11 @@ A list of companies that have paid Developer Community Writer Programs.
 - [PHP Architect](https://www.phparch.com/editorial/write-for-us/) - $175 per piece
   > Thought leadership and technical articles about PHP.
 
-- [Postmark](https://postmarkapp.com/write-for-us) - $200-$300 per piece
-  > Applications are currently closed.
-
 - [QuickNode](https://quicknode.notion.site/quicknode/QuickNode-Authorship-Program-d808a87ee50b48c9a16ed19b13e09115) - $350 per piece
   > Get paid to write articles about cryptocurrencies and web3/blockchain.
 
-- [Rancher](https://rancher.com/writing-program/roles/writer/) - $300 per piece
-  > Writing about devops, Kubernetes, and Rancher.
-
-- [Real Python](https://realpython.com/write-for-us/) - **Applications currently on hold** 
-  > Technical tutorials with code. Pick from a list of possible articles.
-
 - [Sanity.io](https://www.sanity.io/guest-authorship) - Up to $250 per piece
   > Technical focused articles and how-to guides. Pick from a list of possible articles.
-
-- [Section.io](https://github.com/section-io/engineering-education) - $50 to $150 per article
-  > Engineering education blog where Computer Science university students may contribute content for pay.
 
 - [SitePoint](https://sitepoint.typeform.com/to/DMmYfn) - $250 per article
   > Broad coverage of development, design and the business ideas behind them. The JavaScript and PHP channels have the best traffic.
@@ -181,12 +157,13 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Smashing Magazine](https://www.smashingmagazine.com/write-for-us/) - $200 to $250 per article
   > Technical focused articles. No limitation on topics.
 
-- [Software Engineering Daily](https://softwareengineeringdaily.com/write/)
+- [Software Engineering Daily](https://softwareengineeringdaily.com/write/) - Pay unknown
+  > We explain how software is built. We explain how software has gotten us to where we are, and how new software will shape our future.
 
-- [Soshace](https://docs.google.com/document/d/1DZ9Hj8AcNfHI6bC4bfTDIFRNIIFnda6Mkj_n_4x3hWw/edit) - $100 per piece
+- [Soshace](https://blog.soshace.com/write-for-us/) - $100 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
-- [StackOverflow](https://stackoverflow.blog/2020/01/27/blog-contributor-guidelines/?cb=1)
+- [StackOverflow](https://stackoverflow.blog/2020/01/27/blog-contributor-guidelines/?cb=1) - $500 per piece
   > Technical focused articles. No limitation on topics.
 
 - [Strapi](https://strapi.io/write-for-the-community) - Up to $200 per piece
@@ -201,9 +178,6 @@ A list of companies that have paid Developer Community Writer Programs.
 - [TechWell](https://www.techwell.com/techwell-submission-guidelines) - $200 per piece
   > A wide variety of technical and business content is considered.
 
-- [TestDriven.io](https://testdriven.io/blog/) - $300-$500 per guest post
-  > Web development tutorials designed to teach critical skills needed to test, launch, scale, and optimize applications.
-
 - [Topcoder](https://www.topcoder.com/thrive/articles/Submitting%20a%20Thrive%20Article) - $75 per piece
   > Tutorials, workshops and articles are accepted. Get paid to write about Competitive Programming, Data Science, Design, Development, QA and/or Gig Work.
 
@@ -216,20 +190,14 @@ A list of companies that have paid Developer Community Writer Programs.
 - [TypingDNA](https://www.typingdna.com/guest-author-program) - Up to $500 per piece
   > Technical articles/tutorials related to TypingDNA.
 
-- [Vonage](https://developer.nexmo.com/spotlight/) - $500 per piece
+- [Vonage](https://learn.vonage.com/spotlight/) - $500 per piece
   > Technical tutorials and general pieces on programming
 
 - [Vultr](https://www.vultr.com/docs/vultr-docs-program-guidelines) - Up to $600 per piece
   > most topic take a look on Vultr document
 
-- [Webapp.io](https://webapp.io/technical-writer-program) - $150+ per piece
-  > Technical content focused on WebApp projects, Docker, Node and Ruby.
-
-- [WPHUB](https://www.wphub.com/write-for-us/) - $200 per piece
+- [WPHUB](https://www.wphub.com/write-for-us/) - $100-$200 per piece
   > Wordpress tutorials and articles.
-
-- [Enlear](https://www.enlear.com/) - $50 to $150 per article
-  > Get paid to write about broad area of technical topics. Including Vue, Angular, React, Node, JS, DynamoDB
   
 ---
 ## Resources with similar lists

--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Vultr](https://www.vultr.com/docs/vultr-docs-program-guidelines) - Up to $600 per piece
   > most topic take a look on Vultr document
 
+- [Webiny](https://www.webiny.com/docs/write-with-webiny/write-with-webiny) - up to $300 per piece
+  > Articles & tutorials with code covering uses of and projects built with Webiny. You could include things like Gatsby, Next.js, React, Vue, Svelte, GraphQL, Jamstack, Open Source, and Serverless. Join our community to pick from a list of articles we're looking for, or pitch your own.
+
 - [WPHUB](https://www.wphub.com/write-for-us/) - $100-$200 per piece
   > Wordpress tutorials and articles.
   

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Bird Eats Bug](https://jobs.birdeatsbug.com/o/freelance-technical-content-writer-fmx/c/new) - $100 - $300 (Tutorial)
   > Write technical content related to Bird Eats Bug or software development and we will compensate you between $100-$300 for each article of yours that gets publish, depending on the quality and scope of the article.
 
-- [CircleCI](https://circleci.com/blog/guest-writer-program/) - Up to $300 per piece
+- [CircleCI](https://circleci.com/blog/guest-writer-program/) - Up to $325 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
 - [CodeCov](https://about.codecov.io/write-for-us/) - $500 per piece

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Section.io](https://github.com/section-io/engineering-education) - $50 to $150 per article
   > Engineering education blog where Computer Science university students may contribute content for pay.
 
+- [Simple Talk](https://www.red-gate.com/simple-talk/write-for-us/) - 350$ per article
+  > Technical articles focused on SQL Server, MySQL, and Postgres.
+
 - [SitePoint](https://sitepoint.typeform.com/to/DMmYfn) - $250 per article
   > Broad coverage of development, design and the business ideas behind them. The JavaScript and PHP channels have the best traffic.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Nanonet](https://nanonets.com/blog/write-for-us/)
   > Get paid to write about your favourite machine learning topics!
 
-- [MSSQLTips](https://www.mssqltips.com/contribute/) - [100$ per tip](https://www.brentozar.com/archive/2008/12/how-start-blog/)
+- [MSSQLTips](https://www.mssqltips.com/contribute/) - [160$ per tip](https://www.brentozar.com/archive/2008/12/how-start-blog/)
   > Get paid to write about SQL Server and related technologies.
  
 - [Neptune](https://neptune.ai/write-for-us) - Up to $500 per article.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [SitePoint](https://sitepoint.typeform.com/to/DMmYfn) - $250 per article
   > Broad coverage of development, design and the business ideas behind them. The JavaScript and PHP channels have the best traffic.
 
+- [SigNoz](https://signoz.io/technical-writer-program/) - $150 per article
+  > Product tutorials related to SigNoz, and technical content related to topics in our domain like opentelemetry, distributed tracing, application performance monitoring, etc.
+ 
 - [Smashing Magazine](https://www.smashingmagazine.com/write-for-us/) - $200 to $250 per article
   > Technical focused articles. No limitation on topics.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Code Magic](https://blog.codemagic.io/write-for-codemagic-ci-cd/) - Applications are currently closed.
   > Technical focused articles. Specific on Flutter.
 
+- [CodingSight](https://codingsight.com) - Proposed article should be sent to [marketing@devart.com](mailto:marketing@devart.com) (payment depends on the length, research and audience)
+  > Technical articles on SQL Server, PostgreSQL, .NET, Oracle, and Azure.
+  
 - [ContentLab.io](https://contentlab.io/write-for-contentlab/) - Up to $500 per piece
   > Articles on the Cloud, DevOps, Containers, AI/ML, Security, Web, and Gaming spaces.
 
@@ -119,6 +122,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Nanonet](https://nanonets.com/blog/write-for-us/)
   > Get paid to write about your favourite machine learning topics!
 
+- [MSSQLTips](https://www.mssqltips.com/contribute/)
+  > Get paid to write about SQL Server and related technologies.
+ 
 - [Neptune](https://neptune.ai/write-for-us) - Up to $500 per article.
   > Technical articles, how-to guides and tutorials on machine learning and data science.
 
@@ -160,6 +166,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Soshace](https://docs.google.com/document/d/1DZ9Hj8AcNfHI6bC4bfTDIFRNIIFnda6Mkj_n_4x3hWw/edit) - $100 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
+- [SQLShack](https://www.sqlshack.com/about-us/)
+  > Technical focused articles. Specific on SQL Server and related technologies.
+  
 - [StackOverflow](https://stackoverflow.blog/2020/01/27/blog-contributor-guidelines/?cb=1)
   > Technical focused articles. No limitation on topics.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [CodingSight](https://codingsight.com) (Email [marketing@devart.com](mailto:marketing@devart.com)) - $100-$250 per piece
   > Technical articles on SQL Server, PostgreSQL, .NET, Oracle, and Azure.
+
+- [Cohesive](https://cohesiveso.notion.site/Cohesive-Writers-Program-114332379ec8444f8ca0ee774b805253) (Email [writers@cohesive.so](mailto:writers@cohesive.so) - $200-$500 per piece
+  > Technical articles on DevOps, Dev Environments, Docker, Kubernetes, Developer Productivity, Cloud Platforms etc. 
   
 - [ContentLab.io](https://contentlab.io/write-for-contentlab/) - Up to $500 per piece
   > Articles on the Cloud, DevOps, Containers, AI/ML, Security, Web, and Gaming spaces.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [LogRocket](https://blog.logrocket.com/become-a-logrocket-guest-author-7d970eb673f9/) - Up to $350 per piece
   > Technical tutorials with code. Write about anything frontend.
 
+- [Magalix](https://www.magalix.com/the-sac-writers-club) - $200+ per piece
+  > Technical content and tutorials about DevSecOps, Cloud security, Kubernetes security.
+
 - [Magic](https://magic-fortmatic.typeform.com/to/Wgzsocor) - Up to $300 per piece
   [Link to Magic Website](https://magic.link/)
   > Technical tutorials on how to use Magic
@@ -133,6 +136,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Okteto](https://okteto.com/tech-writer/) - $200 per article
     > Technical content and tutorials about Okteto, Kubernetes, and Cloud-Native Applications.
+
+- [OneSignal](https://onesignal.com/guest-author-program) - $350+ per article
+    > Technical content and tutorials about OneSignal, iOS development, Android development.
 
 - [Paperspace](https://blog.paperspace.com/write-for-paperspace/) - $200-$300 per piece
   > Get paid to write articles about machine learning, data science, and more.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [CircleCI](https://circleci.com/blog/guest-writer-program/)  - Up to $300 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
-- Clubhouse.io - Currently returns Error 404 (Not found)
+- Clubhouse.io - Program closed
   > Technical tutorials and how-to guides. Pick from a list of possible articles.
 
 - [Code Tuts+](https://code.tutsplus.com/articles/call-for-authors-write-for-tuts--cms-22034) - $100 (Quick tip) $250 (Tutorial)

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [GraphCMS](https://graphcms.com/write-for-graphcms) - Up to $300 per piece
   > Technical tutorials or blogs with code about GraphCMS or GraphQL with Jamstack or tooling of your choice.
 
-- [Hashnode Web3 Blog](https://web3.hashnode.com/contribute) - from 150$ - 400$ per article
+- [Hashnode Web3 Blog](https://web3.hashnode.com/contribute) - $150 - $400 per article
   > Technical content and tutorials related to Web3.
 
 - [Hasura](https://blog.hasura.io/the-hasura-technical-writer-program/) - Up to $300 per piece

--- a/README.md
+++ b/README.md
@@ -172,6 +172,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [PHP Architect](https://www.phparch.com/editorial/write-for-us/) - $175 per piece
   > Thought leadership and technical articles about PHP.
 
+- [RunX](https://blog.runx.dev/announcing-runxs-technical-writer-program-ea3790f0a80) - $150 for opinion pieces around DevOps and $200 for Tutorials
+  > Get paid to write about DevOps, cloud infrastructure, and Opta.
+
 - [QuickNode](https://quicknode.notion.site/quicknode/QuickNode-Authorship-Program-d808a87ee50b48c9a16ed19b13e09115) - $350 per piece
   > Get paid to write articles about cryptocurrencies and web3/blockchain.
 

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ A list of companies that have paid Developer Community Writer Programs.
   > In-depth tutorials on technical and business topics.
 
 - [Twilio](https://go.twilio.com/twilio-voices/) - Up to $500 per piece
-  > Technical tutorials with code. Doesn't necessarily have to use Twilio.
+  > Technical tutorials that focuses on encouraging developers to build the future of communications.
 
 - [TypingDNA](https://www.typingdna.com/guest-author-program) - Up to $500 per piece
   > Technical articles/tutorials related to TypingDNA.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Okta](https://developer.okta.com/blog) - Paid through Toptal based on your hourly rate
   > Technical tutorials and demos using Okta's products.
+
 - [Okteto](https://okteto.com/tech-writer/) - $200 per article
   > Technical content and tutorials about Okteto, Kubernetes, and Cloud-Native Applications.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [GraphCMS](https://graphcms.com/write-for-graphcms) - Up to $300 per piece
   > Technical tutorials or blogs with code about GraphCMS or GraphQL with Jamstack or tooling of your choice.
 
+- [Hashnode](https://web3.hashnode.com/contribute) - $300 per article
+  > Technical content and tutorials related to Web3.
+
 - [Hasura](https://blog.hasura.io/the-hasura-technical-writer-program/) - Up to $300 per piece
   > Technical tutorials with code about Hasura or GraphQL.
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Nanonet](https://nanonets.com/blog/write-for-us/)
   > Get paid to write about your favourite machine learning topics!
 
-- [MSSQLTips](https://www.mssqltips.com/contribute/)
+- [MSSQLTips](https://www.mssqltips.com/contribute/) - [100$ per tip](https://www.brentozar.com/archive/2008/12/how-start-blog/)
   > Get paid to write about SQL Server and related technologies.
  
 - [Neptune](https://neptune.ai/write-for-us) - Up to $500 per article.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Code Magic](https://blog.codemagic.io/write-for-codemagic-ci-cd/) - Applications are currently closed.
   > Technical focused articles. Specific on Flutter.
 
-- [CodingSight](https://codingsight.com) - Proposed article should be sent to [marketing@devart.com](mailto:marketing@devart.com) (payment depends on the length, research and audience)
+- [CodingSight](https://codingsight.com) - Proposed article should be sent to [marketing@devart.com](mailto:marketing@devart.com) (payment depends on the length, research and audience) - From 100$ to 250$ based on the article technical level
   > Technical articles on SQL Server, PostgreSQL, .NET, Oracle, and Azure.
   
 - [ContentLab.io](https://contentlab.io/write-for-contentlab/) - Up to $500 per piece

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Abstract API](https://www.abstractapi.com/write-for-us) - $100 per article.
   > Technical content and tutorials related to the APIs in their catalogue.
-
 - [Adam the Automator](https://adamtheautomator.com/friends) - $100+ per article
   > Technical tutorials on IT ops, cloud and DevOps topics. You can pick from a list of topics or pitch your own. Run by Microsoft MVP and built to help geeks write better and begin blogging.
 
@@ -21,7 +20,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Agora](https://www.agora.io/en/agora-content-contributor-program/) - $250 per article
   > Technical content and tutorials for the Agora community.
-
 - [Airbyte](https://airbyte.com/write-for-the-community) - $600 per article, you also get paid $300 when your article reaches 1000 views in the first month.
   > Data engineering tutorials, tutorials that cover Airbyte use cases and features.
 
@@ -36,18 +34,18 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Auth0](https://auth0.com/guest-authors) - Up to $450 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
-
 - [Baeldung](https://www.baeldung.com/contribution-guidelines) - $40 - $150 (for articles; they accept also mini-articles and improvments (Java))
   > Baeldung is a technical site focused mainly on the Java ecosystem, but also Kotlin, Scala, Linux, and general Computer Science – with a reach of about 10M page views per month. We publish tutorials and how-to articles – with a very practical, code-focused, and to-the-point style.
 
 - [Bejamas](https://bejamas.io/paid-writing-program/) - Waiting for details
   > Jamstack, serverless and modern web development. Pitch a topic or pick from a list of possible articles
-
 - [Bird Eats Bug](https://birdeatsbug.com/jobs/technical-content-writer) - $100 - $300 (Tutorial)
   > Write technical content related to Bird Eats Bug or software development and we will compensate you between $100-$300 for each article of yours that gets publish, depending on the quality and scope of the article.
-
 - [CircleCI](https://circleci.com/blog/guest-writer-program/)  - Up to $300 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
+
+- [Clubhouse.io](https://clubhouse.io/clubhouse-write-earn-give-program/) - Up to $600 per piece
+  > Technical tutorials and how-to guides. Pick from a list of possible articles.
 
 - [Code Tuts+](https://code.tutsplus.com/articles/call-for-authors-write-for-tuts--cms-22034) - $100 (Quick tip) $250 (Tutorial)
   > Technical focused articles. Pick from a list of possible articles.
@@ -65,16 +63,14 @@ A list of companies that have paid Developer Community Writer Programs.
   > Technical focused articles. No limitation on topics.
 
 - [Cube Dev](https://www.notion.so/Cube-js-Guest-Authors-8ddd5046be9048d9869410b60d4a2b98) — Up to $300 per piece
-  > Technical tutotials and blog posts with code on [Cube.js](https://cube.dev), building analytical apps, data visualization, and data engineering. Pick from a list of possible articles or suggest your own.
-
+  > Technical tutorials and blog posts with code on [Cube.js](https://cube.dev), building analytical apps, data visualization, and data engineering. Pick from a list of possible articles or suggest your own.
+  
 - [Deepsource](https://deepsource.io/tech-writer/) - Around $150 per piece  
   > Technical Content concerning code quality, code review and static analysis
 
 - [Dev Spotlight](https://www.devspotlight.com/jobs/) - Around $300-$500 per piece depending on length and content
   > Technical content production agency that works with many clients.
-
 - [Digital Ocean](https://www.digitalocean.com/write-for-donations/) - Up to $400 per piece **Applications currently on hold, please check back on the first of March 2022!**
-
   > Technical tutorials with code. Not limited to Digital Ocean products.
 
 - [Dockship](https://dockship.io/articles) - $20
@@ -94,7 +90,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Fauna](https://fauna.com/blog/write-with-fauna) - Up to $350 per piece **Applications currently on hold**
   > Content focused on technical education around serverless development and FaunaDB.
-
 - [Figment](https://www.notion.so/Contributing-to-Figment-Learn-d8ff9cdc32ca4b58838d81d07eab49bd) - Around $100 - $1000 per piece
   > Tutorials, guides, and documentation about Blockchain and Web3.
 
@@ -121,7 +116,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [LogRocket](https://blog.logrocket.com/become-a-logrocket-guest-author-7d970eb673f9/) - Up to $350 per piece
   > Technical tutorials with code. Write about anything frontend.
-
 - [Magic](https://magic-fortmatic.typeform.com/to/Wgzsocor) - Up to $300 per piece
   [Link to Magic Website](https://magic.link/)
   > Technical tutorials on how to use Magic
@@ -139,7 +133,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Okta](https://developer.okta.com/blog) - Paid through Toptal based on your hourly rate
   > Technical tutorials and demos using Okta's products.
-
 - [Okteto](https://okteto.com/tech-writer/) - $200 per article
   > Technical content and tutorials about Okteto, Kubernetes, and Cloud-Native Applications.
 
@@ -154,7 +147,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Postmark](https://postmarkapp.com/write-for-us) - $200-$300 per piece
   > Applications are currently closed.
-
 - [QuickNode](https://quicknode.notion.site/quicknode/QuickNode-Authorship-Program-d808a87ee50b48c9a16ed19b13e09115) - $350 per piece
   > Get paid to write articles about cryptocurrencies and web3/blockchain.
 
@@ -198,7 +190,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [TestDriven.io](https://testdriven.io/blog/) - $300-$500 per guest post
   > Web development tutorials designed to teach critical skills needed to test, launch, scale, and optimize applications.
-
 - [Topcoder](https://www.topcoder.com/thrive/articles/Submitting%20a%20Thrive%20Article) - $75 per piece
   > Tutorials, workshops and articles are accepted. Get paid to write about Competitive Programming, Data Science, Design, Development, QA and/or Gig Work.
 
@@ -216,7 +207,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Vultr](https://www.vultr.com/docs/vultr-docs-program-guidelines) - Up to $600 per piece
   > most topic take a look on Vultr document
-
 - [Warrant](https://forms.gle/UyuHRrXc2sE8v1xQ6) - $100 per piece
   > Technical content focused on authorization.
 
@@ -225,7 +215,6 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [WPHUB](https://www.wphub.com/write-for-us/) - $200 per piece
   > Wordpress tutorials and articles.
-
 - [Enlear](https://www.enlear.com/) - $50 to $150 per article
   > Get paid to write about broad area of technical topics. Including Vue, Angular, React, Node, JS, DynamoDB
   

--- a/README.md
+++ b/README.md
@@ -137,9 +137,6 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Okteto](https://okteto.com/tech-writer/) - $200 per article
     > Technical content and tutorials about Okteto, Kubernetes, and Cloud-Native Applications.
 
-- [OneSignal](https://onesignal.com/guest-author-program) - $350+ per article
-    > Technical content and tutorials about OneSignal, iOS development, Android development.
-
 - [Paperspace](https://blog.paperspace.com/write-for-paperspace/) - $200-$300 per piece
   > Get paid to write articles about machine learning, data science, and more.
 

--- a/README.md
+++ b/README.md
@@ -172,11 +172,11 @@ A list of companies that have paid Developer Community Writer Programs.
 - [PHP Architect](https://www.phparch.com/editorial/write-for-us/) - $175 per piece
   > Thought leadership and technical articles about PHP.
 
-- [RunX](https://blog.runx.dev/announcing-runxs-technical-writer-program-ea3790f0a80) - $150 for opinion pieces around DevOps and $200 for Tutorials
-  > Get paid to write about DevOps, cloud infrastructure, and Opta.
-
 - [QuickNode](https://quicknode.notion.site/quicknode/QuickNode-Authorship-Program-d808a87ee50b48c9a16ed19b13e09115) - $350 per piece
   > Get paid to write articles about cryptocurrencies and web3/blockchain.
+
+- [RunX](https://blog.runx.dev/announcing-runxs-technical-writer-program-ea3790f0a80) - $150 for opinion pieces around DevOps and $200 for Tutorials
+  > Get paid to write about DevOps, cloud infrastructure, and Opta.
 
 - [Sanity.io](https://www.sanity.io/guest-authorship) - Up to $250 per piece
   > Technical focused articles and how-to guides. Pick from a list of possible articles.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [Auth0](https://auth0.com/guest-authors) - Up to $450 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
-
+  ** Applications are closed at the moment.**
 - [Baeldung](https://www.baeldung.com/contribution-guidelines) - $40 - $150 (for articles; they accept also mini-articles and improvments (Java))
   > Baeldung is a technical site focused mainly on the Java ecosystem, but also Kotlin, Scala, Linux, and general Computer Science – with a reach of about 10M page views per month. We publish tutorials and how-to articles – with a very practical, code-focused, and to-the-point style.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Nanonet](https://nanonets.com/blog/write-for-us/)
   > Get paid to write about your favourite machine learning topics!
 
-- [MSSQLTips](https://www.mssqltips.com/contribute/) - [160$ per tip](https://www.brentozar.com/archive/2008/12/how-start-blog/)
+- [MSSQLTips](https://www.mssqltips.com/contribute/) - 160$ per tip
   > Get paid to write about SQL Server and related technologies.
  
 - [Neptune](https://neptune.ai/write-for-us) - Up to $500 per article.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ A list of companies that have paid Developer Community Writer Programs.
   
 - [ContentLab.io](https://contentlab.io/write-for-contentlab/) - Up to $500 per piece
   > Articles on the Cloud, DevOps, Containers, AI/ML, Security, Web, and Gaming spaces.
+  
+- [Content Turbine](https://www.contentturbine.com/freelance) - $150+ per piece
+  > Technical content agency. How-to articles, developer guides, and product usecases are among the specialties.
 
 - [Couchbase](https://www.couchbase.com/community/community-writers-program) - $200 per piece
   > Content area experts can submit tutorials and blog content.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ A list of companies that have paid Developer Community Writer Programs.
 - [CircleCI](https://circleci.com/blog/guest-writer-program/)  - Up to $300 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
-- Clubhouse.io - Program closed
-  > Technical tutorials and how-to guides. Pick from a list of possible articles.
-
 - [Code Tuts+](https://code.tutsplus.com/articles/call-for-authors-write-for-tuts--cms-22034) - $100 (Quick tip) $250 (Tutorial)
   > Technical focused articles. Pick from a list of possible articles.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Soshace](https://docs.google.com/document/d/1DZ9Hj8AcNfHI6bC4bfTDIFRNIIFnda6Mkj_n_4x3hWw/edit) - $100 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
-- [SQLShack](https://www.sqlshack.com/about-us/)
+- [SQLShack](https://www.sqlshack.com/about-us/) - 200$ per piece
   > Technical focused articles. Specific on SQL Server and related technologies.
   
 - [StackOverflow](https://stackoverflow.blog/2020/01/27/blog-contributor-guidelines/?cb=1)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Rancher](https://rancher.com/writing-program/roles/writer/) - $300 per piece
   > Writing about devops, Kubernetes, and Rancher.
 
-- [Real Python](https://realpython.com/write-for-us/) - Up to $300 per piece
+- [Real Python](https://realpython.com/write-for-us/) - Applications are currently (as of Aug/21) closed. 
   > Technical tutorials with code. Pick from a list of possible articles.
 
 - [Sanity.io](https://www.sanity.io/guest-authorship) - Up to $250 per piece

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Ambassador Labs](https://www.getambassador.io/write-for-us/) - $300 per article
   > Technical tutorials, guides, opinions and case studies on Kubernetes and open source cloud native technologies.
 
+- [Applozic](https://www.applozic.com/guest-writer/) - $100+ per piece
+  > Tutorials on how to build Chat, Voice, and Video calling apps using Android, iOS or with frontend languages like Javascript frameworks and their respective ecosystems (Angular, Vue, React). 
+
 - [Appsmith](https://blog.appsmith.com/launching-the-appsmith-writers-program) - $200-$400 per piece
   > Internal tools, low code, open-source, databases, application performance, engineering best practices, JavaScript, and Appsmith.
 
@@ -46,14 +49,20 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Bird Eats Bug](https://birdeatsbug.com/jobs/technical-content-writer) - $100 - $300 (Tutorial)
   > Write technical content related to Bird Eats Bug or software development and we will compensate you between $100-$300 for each article of yours that gets publish, depending on the quality and scope of the article.
 
-- [CircleCI](https://circleci.com/blog/guest-writer-program/)  - Up to $300 per piece
+- [CircleCI](https://circleci.com/blog/guest-writer-program/) - Up to $300 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
+
+- [CodeCov](https://about.codecov.io/write-for-us/) - $500 per piece
+  > Technical articles foocused on DevOps and testing. 
 
 - [Code Tuts+](https://code.tutsplus.com/articles/call-for-authors-write-for-tuts--cms-22034) - $100 (Quick tip) $250 (Tutorial)
   > Technical focused articles. Pick from a list of possible articles.
 
 - [Code Magic](https://blog.codemagic.io/write-for-codemagic-ci-cd/) - Pay unknown
   > Technical articles about Flutter.
+
+- [Codiga](https://www.codiga.io/write-for-us/) - $100-$150 per piece
+  > Technical articles focused on code quality.
 
 - [CodingSight](https://codingsight.com) (Email [marketing@devart.com](mailto:marketing@devart.com)) - $100-$250 per piece
   > Technical articles on SQL Server, PostgreSQL, .NET, Oracle, and Azure.
@@ -109,9 +118,15 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Hasura](https://blog.hasura.io/the-hasura-technical-writer-program/) - Up to $300 per piece
   > Technical tutorials with code about Hasura or GraphQL.
 
+- [Hedera](https://github.com/hashgraph/hedera-heroes) - $100 per piece
+  > Articles must feature Hedera technologies and cryptography.
+
+- [Hevo](https://community.hevodata.com/write-for-hevo) - $100 per piece
+  > Technical content related to Data engineering.
+
 - [Hit Subscribe](https://www.hitsubscribe.com/apply-to-be-an-author/) - $100 per piece, $200 for 2x length and ghostwritten articles (Special articles).
   > Technical content production agency that works with many clients.
-
+  
 - [Honeybadger](https://www.honeybadger.io/blog/write-for-us/) - From $500 per piece
   > Ruby and Elixir tutorials with code. Pick from a list of possible articles.
 
@@ -178,6 +193,9 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Software Engineering Daily](https://softwareengineeringdaily.com/write/) - Pay unknown
   > We explain how software is built. We explain how software has gotten us to where we are, and how new software will shape our future.
 
+- [Solace](https://solace.com/scholars/) - $300 per piece
+  > Articles must feature Solace technologies.
+
 - [Soshace](https://blog.soshace.com/write-for-us/) - $100 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
@@ -198,6 +216,9 @@ A list of companies that have paid Developer Community Writer Programs.
 
 - [TechWell](https://www.techwell.com/techwell-submission-guidelines) - $200 per piece
   > A wide variety of technical and business content is considered.
+
+- [TheBotForge](https://www.thebotforge.io/guest-authors/) - up to £200 per article
+  > Technical tutorials, guides and case studies on conversational AI and NLP/NLP/Machine Learning.
 
 - [Topcoder](https://www.topcoder.com/thrive/articles/Submitting%20a%20Thrive%20Article) - $75 per piece
   > Tutorials, workshops and articles are accepted. Get paid to write about Competitive Programming, Data Science, Design, Development, QA and/or Gig Work.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [Adam the Automator](https://adamtheautomator.com/friends) - $100+ per article
   > Technical tutorials on IT ops, cloud and DevOps topics. You can pick from a list of topics or pitch your own. Run by Microsoft MVP and built to help geeks write better and begin blogging.
 
-- [Arctype](https://docs.google.com/document/d/1kBqDcEIKgSftvO-GeXjeqM7WNfaajSpCHm5AZaSyh-Q/edit?usp=sharing) - $100+ per article
+- [Arctype](https://arctype.com/blog/contribute/) - $100+ per article
   > Technical guides, case studies, and thought leadership on SQL and Databases. 
   
 - [Auth0](https://auth0.com/guest-authors) - Up to $300 per piece
@@ -16,7 +16,7 @@ A list of companies that have paid Developer Community Writer Programs.
 - [CircleCI](https://circleci.com/blog/guest-writer-program/)  - Up to $300 per piece
   > Technical tutorials with code. Pick from a list of possible articles.
 
-- [Clubhouse.io](https://clubhouse.io/clubhouse-write-earn-give-program/) - Up to $600 per piece
+- Clubhouse.io - Currently returns Error 404 (Not found)
   > Technical tutorials and how-to guides. Pick from a list of possible articles.
 
 - [Code Tuts+](https://code.tutsplus.com/articles/call-for-authors-write-for-tuts--cms-22034) - $100 (Quick tip) $250 (Tutorial)


### PR DESCRIPTION
[LogRocket ](https://blog.logrocket.com/become-a-logrocket-guest-author/) According to the announcement on their website that read as follows "We’re not accepting new applicants for our guest author program at the moment. Check back soon!"

LogRocket has at least for now paused new application.